### PR TITLE
ci: use `log`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,34 +9,12 @@ jobs:
   publish:
     runs-on: 'ubuntu-latest'
 
+    permissions:
+      contents: 'write'
+      pull-requests: 'read'
+
     steps:
       - uses: 'actions/checkout@v3'
-
-      - name: 'grab tag'
-        run: echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       
-      - name: 'publish release'
-        uses: 'actions/github-script@v6'
-        with:
-          script: |
-            const { readFile } = require('fs/promises')
-              
-            let changelog = await readFile('./changelog.md', { encoding: 'utf-8' })
-              
-            const startIndex = changelog.indexOf(`## [${process.env.TAG}]`) + `## [${process.env.TAG}](https://github.com/azurystudio/cheetah/releases/tag/${process.env.TAG})\n\n`.length
-
-            changelog = changelog.substring(startIndex)
-
-            const endIndex = changelog.indexOf('\n\n## [')
-
-            changelog = changelog.substring(0, endIndex < 0 ? undefined : endIndex)
-
-            github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: process.env.TAG,
-              name: process.env.TAG,
-              body: changelog,
-              draft: false,
-              prerelease: false
-            })
+      - name: 'Publish Release'
+        uses: 'azurystudio/log@v1'

--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,3 @@
-## Upcoming
-
-- **v0.12.0**
-
-  - Implement pre-compilation
-
-- **v0.11.0**
-  - Make `cache` option work with Redis
-  - Implement `ratelimit` plugin
-
 ## [v0.10.0](https://github.com/azurystudio/cheetah/releases/tag/v0.10.0)
 
 - **New Features**


### PR DESCRIPTION
cheetah uses [log](https://github.com/azurystudio/log) from now on to create the changelog and release notes.