### PR TITLE
BREAKING: remove helper methods from context

### DIFF
--- a/core/Collection.ts
+++ b/core/Collection.ts
@@ -1,4 +1,4 @@
-import { Handler, Route } from './Handler.d.ts'
+import { Handler, Route } from './_.ts'
 import { ObjectSchema, Schema } from '../validator/Validator.d.ts'
 
 export class Collection {

--- a/core/Context.d.ts
+++ b/core/Context.d.ts
@@ -2,6 +2,7 @@
 
 import { ContinentCode } from 'https://cdn.jsdelivr.net/npm/@cloudflare/workers-types@4.20230628.0/index.ts'
 import { ObjectSchema, Schema, Static } from '../validator/Validator.d.ts'
+import { RequestMethod } from './_.ts'
 
 export type Context<
   Params extends Record<string, unknown> = Record<string, never>,
@@ -33,13 +34,7 @@ export type Context<
      * @example 'GET'
      * @since v0.12
      */
-    method:
-      | 'DELETE'
-      | 'GET'
-      | 'HEAD'
-      | 'PATCH'
-      | 'POST'
-      | 'PUT'
+    method: RequestMethod
 
     /**
      * Retrieve the unmodified request object with an unread stream of the body.
@@ -146,17 +141,5 @@ export type Context<
      * Redirect the incoming request. *(temporary redirect by default)*
      */
     redirect: (destination: string, code?: number) => void
-
-    blob: (blob: Blob | File, code?: number) => void
-
-    stream: (stream: ReadableStream<unknown>, code?: number) => void
-
-    formData: (formData: FormData, code?: number) => void
-
-    buffer: (buffer: Uint8Array | ArrayBuffer, code?: number) => void
-
-    json: (json: Record<string, unknown>, code?: number) => void
-
-    text: (text: string, code?: number) => void
   }
 }

--- a/core/Router.ts
+++ b/core/Router.ts
@@ -1,4 +1,4 @@
-import { Route } from './Handler.d.ts'
+import { Route } from './_.ts'
 
 export class Router {
   #routes: [string, RegExp, Route[]][] = []

--- a/core/_.ts
+++ b/core/_.ts
@@ -2,6 +2,14 @@
 import { Context } from './Context.d.ts'
 import { ObjectSchema, Schema } from '../validator/Validator.d.ts'
 
+export type RequestMethod =
+  | 'DELETE'
+  | 'GET'
+  | 'HEAD'
+  | 'PATCH'
+  | 'POST'
+  | 'PUT'
+
 export type Route =
   | {
     body?: Schema
@@ -25,10 +33,15 @@ type ExtractParams<Path> = Path extends `${infer Segment}/${infer Rest}`
   : ExtractParam<Path, {}>
 
 export type ResponsePayload =
-  | string
+  | ArrayBuffer
+  | Blob
+  | FormData
+  | ReadableStream<unknown>
   | Record<string, unknown>
-  | void
+  | Uint8Array
+  | string
   | undefined
+  | void
 
 export type Handler<
   Params = unknown,

--- a/core/createPlugin.ts
+++ b/core/createPlugin.ts
@@ -1,5 +1,5 @@
 import { Context } from './Context.d.ts'
-import { ResponsePayload } from './Handler.d.ts'
+import { ResponsePayload } from './_.ts'
 
 export type PluginMethods = {
   beforeParsing?: (request: Request) => void | Promise<void>

--- a/test/response.test.ts
+++ b/test/response.test.ts
@@ -53,10 +53,12 @@ Deno.test('Response', async (t) => {
     assertEquals(response2.headers.get('location'), 'https://deno.com')
   })
 
-  await t.step('res.blob()', async () => {
+  await t.step('blob', async () => {
     const blob = new Blob([new TextEncoder().encode('test')])
 
-    app.get('/blob', (c) => c.res.blob(blob))
+    app.get('/blob', () => {
+      return blob
+    })
 
     assertEquals(
       new TextDecoder().decode(
@@ -68,8 +70,10 @@ Deno.test('Response', async (t) => {
     )
   })
 
-  await t.step('res.stream()', async () => {
-    app.get('/stream', (c) => c.res.stream(new ReadableStream()))
+  await t.step('stream', async () => {
+    app.get('/stream', () => {
+      return new ReadableStream()
+    })
 
     assertEquals(
       (await app.fetch(new Request('http://localhost:3000/stream'))).body !==
@@ -78,12 +82,12 @@ Deno.test('Response', async (t) => {
     )
   })
 
-  await t.step('res.formData()', async () => {
+  await t.step('formData', async () => {
     const formData = new FormData()
     formData.append('one', 'field')
 
-    app.get('/formData', (c) => {
-      c.res.formData(formData)
+    app.get('/formData', () => {
+      return formData
     })
 
     assertEquals(
@@ -93,12 +97,12 @@ Deno.test('Response', async (t) => {
     )
   })
 
-  await t.step('res.buffer()', async () => {
+  await t.step('buffer', async () => {
     const buffer = new TextEncoder().encode('test')
     const arrayBuffer = buffer.buffer
 
-    app.get('/buffer', (c) => {
-      c.res.buffer(buffer)
+    app.get('/buffer', () => {
+      return buffer
     })
 
     assertEquals(
@@ -108,37 +112,29 @@ Deno.test('Response', async (t) => {
     )
   })
 
-  await t.step('res.json()', async () => {
-    app.get('/json', (c) => c.res.json({ message: 'test' }))
-    assertEquals(
-      await (await app.fetch(new Request('http://localhost:3000/json'))).json(),
-      { message: 'test' },
-    )
-  })
+  await t.step('json', async () => {
+    app.get('/json', () => {
+      return {
+        message: 'test',
+      }
+    })
 
-  await t.step('res.text()', async () => {
-    app.get('/text', (c) => c.res.text('test'))
-    assertEquals(
-      await (await app.fetch(new Request('http://localhost:3000/text'))).text(),
-      'test',
-    )
-  })
-
-  await t.step('Implicit JSON', async () => {
-    app.get('/implicit-json', () => ({ message: 'test' }))
     assertEquals(
       await (await app.fetch(
-        new Request('http://localhost:3000/implicit-json'),
+        new Request('http://localhost:3000/json'),
       )).json(),
       { message: 'test' },
     )
   })
 
-  await t.step('Implicit Text', async () => {
-    app.get('/implicit-text', () => 'test')
+  await t.step('text', async () => {
+    app.get('/text', () => {
+      return 'test'
+    })
+
     assertEquals(
       await (await app.fetch(
-        new Request('http://localhost:3000/implicit-text'),
+        new Request('http://localhost:3000/text'),
       )).text(),
       'test',
     )


### PR DESCRIPTION
This pr removes the following methods from the context object:

- `c.res.blob()`
- `c.res.buffer()`
- `c.res.formData()`
- `c.res.json()`
- `c.res.stream()`
- `c.res.string()`
- `c.res.text()`

These methods are completely superfluous, as you can simply `return` them, which is, first of all, faster, and secondly, much more convenient.