### PR TITLE
feat: `c.res.bodySize` getter

### DIFF
--- a/core/context/ResponseContext.ts
+++ b/core/context/ResponseContext.ts
@@ -20,9 +20,48 @@ export class ResponseContext {
   }
 
   /**
-   * Set the status code of the response.
+   * The size of the response body (`-1` if it cannot be calculated).
    */
-  code(code: number) {
+  get bodySize() {
+    if (
+      this.#i.b === null
+    ) {
+      return 0
+    }
+
+    if (
+      this.#i.b instanceof ReadableStream ||
+      this.#i.b instanceof FormData
+    ) {
+      return -1
+    }
+
+    let bodySize = -1
+
+    if (typeof this.#i.b === 'string') {
+      bodySize = this.#i.b.length
+    } else if (
+      this.#i.b instanceof ArrayBuffer ||
+      this.#i.b instanceof Uint8Array
+    ) {
+      bodySize = this.#i.b.byteLength
+    } else if (this.#i.b instanceof Blob) {
+      bodySize = this.#i.b.size
+    } else {
+      bodySize = JSON.stringify(this.#i.b).length
+    }
+
+    return bodySize
+  }
+
+  /**
+   * The status code of the response.
+   */
+  get code() {
+    return this.#i.c
+  }
+
+  set code(code: number) {
     this.#i.c = code
   }
 

--- a/test/response.test.ts
+++ b/test/response.test.ts
@@ -4,11 +4,30 @@ import cheetah from '../mod.ts'
 Deno.test('Response', async (t) => {
   const app = new cheetah()
 
-  await t.step('res.code()', async () => {
-    app.get('/code', (c) => c.res.code(101))
+  await t.step('res.code', async () => {
+    app.get('/code', (c) => {
+      c.res.code = 101
+    })
     assertEquals(
       (await app.fetch(new Request('http://localhost:3000/code'))).status,
       101,
+    )
+  })
+
+  await t.step('res.bodySize', async () => {
+    app.get('/body_size', (c) => {
+      c.res.body = 'hello world'
+
+      return c.res.bodySize.toString()
+    })
+
+    const result = await app.fetch(
+      new Request('http://localhost:3000/body_size'),
+    )
+
+    assertEquals(
+      await result.text(),
+      'hello world'.length.toString(),
     )
   })
 


### PR DESCRIPTION
This pr introduces a method that allows you to get the size of the response body.