### PR TITLE
BREAKING: remove `cache` option

### DIFF
--- a/Collection.ts
+++ b/Collection.ts
@@ -3,13 +3,6 @@ import { base, Method } from './base.ts'
 import { HandlerOrSchema } from './handler.ts'
 
 export class Collection extends base<Collection>() {
-  #cache:
-    | false
-    | {
-      maxAge: number
-    }
-    | undefined
-
   #cors:
     | string
     | undefined
@@ -21,19 +14,8 @@ export class Collection extends base<Collection>() {
   ][]
 
   constructor({
-    cache,
     cors,
   }: {
-    /**
-     * Duration in seconds for how long a response should be cached.
-     *
-     * @since v0.11
-     */
-    cache?:
-      | false
-      | {
-        maxAge: number
-      }
     /**
      * Enable Cross-Origin Resource Sharing (CORS) for this collection by setting a origin, e.g. `*`.
      *
@@ -42,11 +24,7 @@ export class Collection extends base<Collection>() {
     cors?: string
   } = {}) {
     super((method, pathname, handlers) => {
-      if ((this.#cache || this.#cors) && typeof handlers[0] !== 'function') {
-        if (handlers[0].cache === undefined && this.#cache !== undefined) {
-          handlers[0].cache = this.#cache
-        }
-
+      if (this.#cors && typeof handlers[0] !== 'function') {
         if (!handlers[0].cors) {
           handlers[0].cors = this.#cors
         }
@@ -57,9 +35,7 @@ export class Collection extends base<Collection>() {
       return this
     })
 
-    this.routes = []
-
-    this.#cache = cache
     this.#cors = cors
+    this.routes = []
   }
 }

--- a/handler.ts
+++ b/handler.ts
@@ -77,7 +77,6 @@ export function handler<T>() {
         headers?: ValidatedHeaders
         query?: ValidatedQuery
         transform?: boolean
-        cache?: false | { maxAge: number }
         cors?: string
       }
       | Handler<
@@ -125,7 +124,6 @@ export function bodylessHandler<T>() {
         cookies?: ValidatedCookies
         headers?: ValidatedHeaders
         query?: ValidatedQuery
-        cache?: false | { maxAge: number }
         cors?: string
       }
       | BodylessHandler<
@@ -148,7 +146,6 @@ export type HandlerOrSchema =
     headers?: ObjectType
     query?: ObjectType
     transform?: boolean
-    cache?: false | { maxAge: number }
     cors?: string
   }
   | Handler<unknown>


### PR DESCRIPTION
Caching shouldn't be handled at an framework, global level. It's prone to severe authentication bugs (users can access content without providing credentials).

That's why there'll be a helper class, which will make it really easy to cache content while staying on the safe side.