### PR TITLE
fix: don't calculate content length

### DIFF
--- a/cheetah.ts
+++ b/cheetah.ts
@@ -439,8 +439,6 @@ export class cheetah extends base<cheetah>() {
 
     switch ($.b.constructor.name) {
       case 'String': {
-        $.h.set('content-length', ($.b as string).length.toString())
-
         if (!$.h.has('content-type')) {
           $.h.set('content-type', 'text/plain; charset=utf-8')
         }
@@ -450,8 +448,6 @@ export class cheetah extends base<cheetah>() {
 
       case 'Object': {
         $.b = JSON.stringify($.b)
-
-        $.h.set('content-length', $.b.length.toString())
 
         if (!$.h.has('content-type')) {
           $.h.set('content-type', 'application/json; charset=utf-8')
@@ -464,25 +460,17 @@ export class cheetah extends base<cheetah>() {
         break
       }
 
-      case 'ArrayBuffer': {
-        $.h.set('content-length', ($.b as ArrayBuffer).byteLength.toString())
+      case 'Array': {
+        $.b = JSON.stringify($.b)
+
+        if (!$.h.has('content-type')) {
+          $.h.set('content-type', 'application/json; charset=utf-8')
+        }
 
         break
       }
 
-      case 'Uint8Array': {
-        $.h.set('content-length', ($.b as Uint8Array).byteLength.toString())
-
-        break
-      }
-
-      case 'Blob': {
-        $.h.set('content-length', ($.b as Blob).size.toString())
-
-        break
-      }
-
-      default: // FormData or ReadableStream
+      default:
         break
     }
 

--- a/test/preflight_mode.test.ts
+++ b/test/preflight_mode.test.ts
@@ -17,21 +17,18 @@ Deno.test('preflight mode', async (t) => {
     const res1 = await app.fetch(new Request('https://deno.com/foo1'))
 
     assertEquals(res1.body === null, false)
-    assertEquals(res1.headers.get('content-length'), '4')
 
     const res2 = await app.fetch(
       new Request('https://deno.com/foo1', { method: 'HEAD' }),
     )
 
     assertEquals(res2.body === null, true)
-    assertEquals(res2.headers.get('content-length'), '4')
 
     const res3 = await app.fetch(
       new Request('https://deno.com/foo2', { method: 'POST' }),
     )
 
     assertEquals(res3.body === null, false)
-    assertEquals(res3.headers.get('content-length'), '4')
 
     const res4 = await app.fetch(
       new Request('https://deno.com/foo2', { method: 'HEAD' }),
@@ -39,10 +36,6 @@ Deno.test('preflight mode', async (t) => {
 
     assertEquals(res4.status, 404)
     assertEquals(res4.body === null, true)
-    assertEquals(
-      res4.headers.get('content-length'),
-      'Not Found'.length.toString(),
-    )
   })
 
   await t.step('not found', async () => {
@@ -51,20 +44,12 @@ Deno.test('preflight mode', async (t) => {
     const res1 = await app.fetch(new Request('https://deno.com/foo'))
 
     assertEquals(res1.body === null, false)
-    assertEquals(
-      res1.headers.get('content-length'),
-      'Not Found'.length.toString(),
-    )
 
     const res2 = await app.fetch(
       new Request('https://deno.com/foo', { method: 'HEAD' }),
     )
 
     assertEquals(res2.body === null, true)
-    assertEquals(
-      res2.headers.get('content-length'),
-      'Not Found'.length.toString(),
-    )
   })
 
   await t.step('not found (custom)', async () => {


### PR DESCRIPTION
A invalid `content-length` header caused incorrect rendering of emojis. The header also isn't necessary if you don't respond with a `ReadableStream`, so it's now gone with this pull request.