### PR TITLE
fix: always require `next` call

### DIFF
--- a/cheetah.ts
+++ b/cheetah.ts
@@ -396,14 +396,14 @@ export class cheetah extends base<cheetah>() {
 
     const len = handlers.length
 
-    let next = false
+    let next = true
 
     for (let i = 0; i < len; ++i) {
       if (typeof handlers[i] !== 'function') {
         continue
       }
 
-      if ($.b && !next) {
+      if (!next) {
         break
       }
 

--- a/test/many_handlers.test.ts
+++ b/test/many_handlers.test.ts
@@ -5,7 +5,7 @@ import cheetah from '../mod.ts'
 Deno.test('Many Handlers', async () => {
   const app = new cheetah()
 
-  app.get('/test', (_, next) => {
+  app.get('/a', (_, next) => {
     next()
 
     return 'a'
@@ -15,15 +15,39 @@ Deno.test('Many Handlers', async () => {
     }
   })
 
+  app.get('/b', (c) => {
+    c.res.header('foo', 'bar')
+  }, (c) => {
+    c.res.header('foo', 'foo')
+  })
+
+  app.get('/c', (c, next) => {
+    c.res.header('foo', 'bar')
+
+    next()
+  }, (c) => {
+    c.res.header('foo', 'foo')
+  })
+
   assertEquals(
-    await (await app.fetch(new Request('http://localhost/test'))).text(),
+    await (await app.fetch(new Request('http://localhost/a'))).text(),
     'a',
   )
 
   assertEquals(
     await (await app.fetch(
-      new Request('http://localhost/test', { headers: { 'foo': 'bar' } }),
+      new Request('http://localhost/a', { headers: { 'foo': 'bar' } }),
     )).text(),
     'b',
+  )
+
+  assertEquals(
+    (await app.fetch(new Request('http://localhost/b'))).headers.get('foo'),
+    'bar',
+  )
+
+  assertEquals(
+    (await app.fetch(new Request('http://localhost/c'))).headers.get('foo'),
+    'foo',
   )
 })


### PR DESCRIPTION
If you have multiple handlers for a route, you now need to always call the `next` function if don't want to stop the execution.