### PR TITLE
refactor: move `transform` option to `c.req.body()`

### DIFF
--- a/handler.ts
+++ b/handler.ts
@@ -72,7 +72,8 @@ export function handler<T>() {
         cookies?: ValidatedCookies
         headers?: ValidatedHeaders
         query?: ValidatedQuery
-        transform?: boolean
+        /** @deprecated please pass this option to the `c.req.body()` method! */
+        transform?: boolean // TODO remove at v2.0
         cors?: string
       }
       | Handler<
@@ -141,7 +142,8 @@ export type HandlerOrSchema =
     cookies?: ObjectType
     headers?: ObjectType
     query?: ObjectType
-    transform?: boolean
+    /** @deprecated please pass this option to the `c.req.body()` method! */
+    transform?: boolean // TODO remove at v2.0
     cors?: string
   }
   | Handler<unknown>

--- a/request_context.ts
+++ b/request_context.ts
@@ -84,7 +84,14 @@ export class RequestContext<
   /**
    * The validated body of the incoming request.
    */
-  async body(): Promise<
+  async body(options?: {
+    /**
+     * This enables the conversion of a FormData request body into a JSON object (if the request body has the MIME type `multipart/form-data`).
+     * 
+     * @default false
+     */
+    transform: boolean
+  }): Promise<
     ValidatedBody extends ZodType ? Static<ValidatedBody> : unknown
   > {
     if (!this.#s?.body) {
@@ -106,7 +113,7 @@ export class RequestContext<
         body = await resolveWithDeadline(this.#r.text(), 3000)
       } else {
         if (
-          this.#s?.transform === true &&
+          (options?.transform === true || this.#s?.transform === true) &&
           this.#r.headers.get('content-type') === 'multipart/form-data'
         ) {
           const formData = await resolveWithDeadline(this.#r.formData(), 3000)

--- a/request_context.ts
+++ b/request_context.ts
@@ -87,7 +87,7 @@ export class RequestContext<
   async body(options?: {
     /**
      * This enables the conversion of a FormData request body into a JSON object (if the request body has the MIME type `multipart/form-data`).
-     * 
+     *
      * @default false
      */
     transform: boolean

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -4,32 +4,68 @@ import { assertEquals } from 'https://deno.land/std@0.194.0/testing/asserts.ts'
 import z from 'https://deno.land/x/zod@v3.21.4/index.ts'
 
 Deno.test('Validation', async (t) => {
-  await t.step('transform', async () => {
+  await t.step('transform', async (t) => {
     const app = new cheetah()
 
-    app.post('/one', {
-      body: z.object({
-        message: z.string(),
-      }),
-      transform: true,
-    }, async (c) => {
-      assertEquals(await c.req.body(), { message: 'Hello World' })
+    // TODO remove at v2.0
+    await t.step('original (deprecated)', async () => {
+      app.post('/transform_original', {
+        body: z.object({
+          message: z.string(),
+        }),
+        transform: true,
+      }, async (c) => {
+        assertEquals(await c.req.body(), { message: 'Hello World' })
 
-      return 'test'
+        return 'test'
+      })
+
+      const form = new FormData()
+      form.append('message', 'Hello World')
+      await (await app.fetch(
+        new Request('http://localhost/transform_original', {
+          method: 'POST',
+          body: form,
+        }),
+      )).text()
+
+      await (await app.fetch(
+        new Request('http://localhost/transform_original', {
+          method: 'POST',
+          body: JSON.stringify({ message: 'Hello World' }),
+        }),
+      )).text()
     })
 
-    const form = new FormData()
-    form.append('message', 'Hello World')
-    await (await app.fetch(
-      new Request('http://localhost/one', { method: 'POST', body: form }),
-    )).text()
+    await t.step('new', async () => {
+      app.post('/transform', {
+        body: z.object({
+          message: z.string(),
+        }),
+      }, async (c) => {
+        assertEquals(await c.req.body({ transform: true }), {
+          message: 'Hello World',
+        })
 
-    await (await app.fetch(
-      new Request('http://localhost/one', {
-        method: 'POST',
-        body: JSON.stringify({ message: 'Hello World' }),
-      }),
-    )).text()
+        return 'test'
+      })
+
+      const form = new FormData()
+      form.append('message', 'Hello World')
+      await (await app.fetch(
+        new Request('http://localhost/transform', {
+          method: 'POST',
+          body: form,
+        }),
+      )).text()
+
+      await (await app.fetch(
+        new Request('http://localhost/transform', {
+          method: 'POST',
+          body: JSON.stringify({ message: 'Hello World' }),
+        }),
+      )).text()
+    })
   })
 
   await t.step('cookies', async () => {


### PR DESCRIPTION
The original option has been marked as deprecated and will be removed at v2.0.