### PR TITLE
feat: `c.exception()`

### DIFF
--- a/exception.ts
+++ b/exception.ts
@@ -26,6 +26,8 @@
  * throw new Exception('Too Many Requests')
  * throw new Exception(429)
  * ```
+ *
+ * @deprecated please use `c.exception()` instead!
  */
 export class Exception {
   public response


### PR DESCRIPTION
This method is the successor to the original `Exception` class which is now deprecated.