### PR TITLE
fix(context/exception): return exception

### DIFF
--- a/context.ts
+++ b/context.ts
@@ -151,7 +151,7 @@ export class Context<
   exception(error: keyof typeof HTTP_MESSAGES, description?: string) {
     const code = HTTP_MESSAGES[error]
 
-    throw new Exception(error, description, code)
+    return new Exception(error, description, code)
   }
 }
 


### PR DESCRIPTION
Previously, the `c.exception()` method threw the constructed exception instead of returning it. Throwing it is nice but doesn't help a lot because TypeScript can't figure that out sadly thus it doesn't know that execution of a script did stop when you call that method.

You should use it like that: `throw c.exception(...)`