### PR TITLE
feat(render): dynamic head content

### DIFF
--- a/render.ts
+++ b/render.ts
@@ -15,9 +15,13 @@ const HEAD_TAG = '<head>'
 
 export function render(c: Context, Component: VNode) {
   const htmlString = renderToString(Component)
-
+  c.res.header('content-type', 'text/html; charset=utf-8')
   try {
     const { html, css } = extract(htmlString)
+    if (css.length === 0) {
+      c.res.body = html
+      return
+    }
     const startIdxOfHeadContent = html.indexOf(HEAD_TAG)
     const endIdxOfHeadContent = html.indexOf(
       '</head>',
@@ -32,7 +36,7 @@ export function render(c: Context, Component: VNode) {
         : ''
     c.res.body = html.replace(
       headContent,
-      `${headContent}${css.length > 0 ? `<style>${css}</style>` : ''}`,
+      `${headContent}<style>${css}</style>`,
     )
   } catch (_err) {
     if (c.dev) {
@@ -44,11 +48,8 @@ export function render(c: Context, Component: VNode) {
         ),
       )
     }
-
     c.res.body = htmlString
   }
-
-  c.res.header('content-type', 'text/html; charset=utf-8')
 }
 
 export class Renderer {

--- a/render.ts
+++ b/render.ts
@@ -18,6 +18,7 @@ export function render(c: Context, Component: VNode) {
 
   try {
     const { html, css } = extract(htmlString)
+    console.log(css.length)
     const startIdxOfHeadContent = html.indexOf(HEAD_TAG)
     const endIdxOfHeadContent = html.indexOf(
       `${HEAD_TAG.at(0)}/${HEAD_TAG.slice(1)}`,
@@ -32,7 +33,7 @@ export function render(c: Context, Component: VNode) {
         : ''
     c.res.body = html.replace(
       headContent,
-      `${headContent}<style>${css}</style>`,
+      `${headContent}${css.length > 0 ? `<style>${css}</style>` : ''}`,
     )
   } catch (_err) {
     if (c.dev) {

--- a/render.ts
+++ b/render.ts
@@ -18,10 +18,9 @@ export function render(c: Context, Component: VNode) {
 
   try {
     const { html, css } = extract(htmlString)
-    console.log(css.length)
     const startIdxOfHeadContent = html.indexOf(HEAD_TAG)
     const endIdxOfHeadContent = html.indexOf(
-      `${HEAD_TAG.at(0)}/${HEAD_TAG.slice(1)}`,
+      '</head>',
     )
     const headContent =
       startIdxOfHeadContent >= 0 && endIdxOfHeadContent >= 0 &&

--- a/render.ts
+++ b/render.ts
@@ -17,7 +17,10 @@ export function render(c: Context, Component: VNode) {
   try {
     const { html, css } = extract(htmlString)
 
-    c.res.body = `<style>${css}</style><body>${html}</body>`
+    c.res.body = html.replace(
+      css,
+      `<style>${css}</style>`,
+    )
   } catch (_err) {
     if (c.dev) {
       console.warn(

--- a/render.ts
+++ b/render.ts
@@ -11,15 +11,28 @@ import renderToString from 'https://esm.sh/preact-render-to-string@6.1.0?deps=pr
 import { VNode } from 'https://esm.sh/preact@10.17.1?target=es2022'
 import { Context } from './mod.ts'
 
+const HEAD_TAG = '<head>'
+
 export function render(c: Context, Component: VNode) {
   const htmlString = renderToString(Component)
 
   try {
     const { html, css } = extract(htmlString)
-
+    const startIdxOfHeadContent = html.indexOf(HEAD_TAG)
+    const endIdxOfHeadContent = html.indexOf(
+      `${HEAD_TAG.at(0)}/${HEAD_TAG.slice(1)}`,
+    )
+    const headContent =
+      startIdxOfHeadContent >= 0 && endIdxOfHeadContent >= 0 &&
+        endIdxOfHeadContent > startIdxOfHeadContent
+        ? html.slice(
+          startIdxOfHeadContent + HEAD_TAG.length,
+          endIdxOfHeadContent,
+        )
+        : ''
     c.res.body = html.replace(
-      css,
-      `<style>${css}</style>`,
+      headContent,
+      `${headContent}<style>${css}</style>`,
     )
   } catch (_err) {
     if (c.dev) {

--- a/render.ts
+++ b/render.ts
@@ -11,33 +11,11 @@ import renderToString from 'https://esm.sh/preact-render-to-string@6.1.0?deps=pr
 import { VNode } from 'https://esm.sh/preact@10.17.1?target=es2022'
 import { Context } from './mod.ts'
 
-const HEAD_TAG = '<head>'
-
 export function render(c: Context, Component: VNode) {
   const htmlString = renderToString(Component)
-  c.res.header('content-type', 'text/html; charset=utf-8')
   try {
     const { html, css } = extract(htmlString)
-    if (css.length === 0) {
-      c.res.body = html
-      return
-    }
-    const startIdxOfHeadContent = html.indexOf(HEAD_TAG)
-    const endIdxOfHeadContent = html.indexOf(
-      '</head>',
-    )
-    const headContent =
-      startIdxOfHeadContent >= 0 && endIdxOfHeadContent >= 0 &&
-        endIdxOfHeadContent > startIdxOfHeadContent
-        ? html.slice(
-          startIdxOfHeadContent + HEAD_TAG.length,
-          endIdxOfHeadContent,
-        )
-        : ''
-    c.res.body = html.replace(
-      headContent,
-      `${headContent}<style>${css}</style>`,
-    )
+    c.res.body = `${css.length > 0 ? `<style>${css}</style>` : ''}${html}`
   } catch (_err) {
     if (c.dev) {
       console.warn(
@@ -50,6 +28,7 @@ export function render(c: Context, Component: VNode) {
     }
     c.res.body = htmlString
   }
+  c.res.header('content-type', 'text/html; charset=utf-8')
 }
 
 export class Renderer {

--- a/test/render.test.tsx
+++ b/test/render.test.tsx
@@ -1,6 +1,6 @@
 // Copyright 2023 Samuel Kopp. All rights reserved. Apache-2.0 license.
 /** @jsx h */
-import { VNode } from 'https://esm.sh/v128/preact@10.17.1'
+import { Fragment, VNode } from 'https://esm.sh/preact@10.17.1'
 import cheetah, { h, Renderer } from '../mod.ts'
 import { assert, assertEquals, DOMParser, z } from './deps.ts'
 
@@ -37,18 +37,36 @@ const Unstyled = () => {
   )
 }
 
+const MetaTagsWithoutWrappers = () => {
+  return (
+    <>
+      <title>This is a document!</title>
+      <meta charSet='utf-8' />
+      <h1>Hello world!</h1>
+    </>
+  )
+}
+
 const app = new cheetah()
 
 const { render } = new Renderer()
 
 app.get('/render', {
   query: z.object({
-    type: z.union([z.literal('styled'), z.literal('unstyled')]),
+    type: z.union([
+      z.literal('styled'),
+      z.literal('unstyled'),
+      z.literal('meta-tags-without-wrappers'),
+    ]),
   }),
 }, (ctx) => {
+  const type = ctx.req.query.type
+  if (type === 'meta-tags-without-wrappers') {
+    return render(ctx, <MetaTagsWithoutWrappers />)
+  }
   render(
     ctx,
-    ctx.req.query.type === 'styled' ? <Styled /> : <Unstyled />,
+    type === 'styled' ? <Styled /> : <Unstyled />,
   )
 })
 
@@ -109,6 +127,44 @@ Deno.test('render', async (test) => {
         childNode.tagName === 'TITLE' &&
         childNode.textContent === 'This is a document!'
       ),
+    )
+  })
+
+  await test.step('Even without the essential html, head and body tags in the JSX input, the JSX input is injected correctly into the appropriate places.', async () => {
+    const renderResponse = await app.fetch(
+      new Request('http://localhost/render?type=meta-tags-without-wrappers'),
+    )
+    const htmlText = await renderResponse.text()
+    const document = new DOMParser().parseFromString(
+      htmlText,
+      'text/html',
+    )
+    assert(document)
+    const { documentElement } = document
+    assert(documentElement)
+    const headElementsInDocument = documentElement.getElementsByTagName('head')
+    const [headElement] = headElementsInDocument
+    assert(headElement)
+    const titleElementInDocument = headElement.getElementsByTagName('title').at(
+      0,
+    )
+    assert(
+      titleElementInDocument &&
+        titleElementInDocument.textContent === 'This is a document!',
+    )
+    const metaTagsInDocument = documentElement.getElementsByTagName('meta')
+    assert(
+      metaTagsInDocument.find((metaTag) =>
+        metaTag.getAttribute('charset') === 'utf-8'
+      ),
+    )
+    const [bodyElement] = documentElement.getElementsByTagName('body')
+    assert(bodyElement)
+    const [headingElementInBody] = [...bodyElement.children]
+    assert(
+      headingElementInBody !== undefined &&
+        headingElementInBody.tagName === 'H1' &&
+        headingElementInBody.textContent === 'Hello world!',
     )
   })
 })

--- a/test/render.test.tsx
+++ b/test/render.test.tsx
@@ -1,70 +1,114 @@
 // Copyright 2023 Samuel Kopp. All rights reserved. Apache-2.0 license.
 /** @jsx h */
+import { VNode } from 'https://esm.sh/v128/preact@10.17.1'
 import cheetah, { h, Renderer } from '../mod.ts'
-import { assert, assertEquals, DOMParser } from './deps.ts'
+import { assert, assertEquals, DOMParser, z } from './deps.ts'
 
-Deno.test('render', async () => {
-  const app = new cheetah()
+const Document = ({ children }: { children: VNode }) => {
+  return (
+    <html>
+      <head>
+        <title>This is a document!</title>
+      </head>
+      <body>
+        {children}
+      </body>
+    </html>
+  )
+}
 
-  const { render } = new Renderer()
-
-  function Styled() {
-    return (
+const Styled = () => {
+  return (
+    <Document>
       <h3 class='text-sm italic' id='styled'>
         styled <code class='font-mono'>h3</code> component
       </h3>
-    )
-  }
-
-  app.get('/a', (c) => render(c, <Styled />))
-
-  const a = await app.fetch(new Request('http://localhost/a'))
-
-  const tx = await a.text()
-
-  const document = new DOMParser().parseFromString(
-    tx,
-    'text/html',
+    </Document>
   )
+}
 
-  assert(document)
-  assert([...document.getElementsByTagName('style')].length)
-  assertEquals(
-    document.getElementById('styled')?.innerText,
-    'styled h3 component',
+const Unstyled = () => {
+  return (
+    <Document>
+      <h3 id='unstyled'>
+        unstyled <code>h3</code> component
+      </h3>
+    </Document>
   )
-  assertEquals(
-    a.headers.get('content-type'),
-    'text/html; charset=utf-8',
-  )
-})
+}
 
-Deno.test('No empty style tag is injected if no twind styles are utilised.', async () => {
+Deno.test('render', async (test) => {
   const app = new cheetah()
 
   const { render } = new Renderer()
 
-  function NonStyled() {
-    return (
-      <h3 id='styled'>
-        non-styled <code>h3</code> component
-      </h3>
+  app.get('/render', {
+    query: z.object({
+      type: z.union([z.literal('styled'), z.literal('unstyled')]),
+    }),
+  }, (ctx) => {
+    render(
+      ctx,
+      ctx.req.query.type === 'styled' ? <Styled /> : <Unstyled />,
     )
-  }
+  })
 
-  app.get('/a', (c) => render(c, <NonStyled />))
+  await test.step('Twind styles are applied to the resulting HTML correctly', async () => {
+    const renderResponse = await app.fetch(
+      new Request('http://localhost/render?type=styled'),
+    )
+    const htmlText = await renderResponse.text()
+    const document = new DOMParser().parseFromString(
+      htmlText,
+      'text/html',
+    )
+    assert(document)
+    assert([...document.getElementsByTagName('style')].length === 1)
+    assertEquals(
+      document.getElementById('styled')?.innerText,
+      'styled h3 component',
+    )
+    assertEquals(
+      renderResponse.headers.get('content-type'),
+      'text/html; charset=utf-8',
+    )
+  })
 
-  const a = await app.fetch(new Request('http://localhost/a'))
-
-  const tx = await a.text()
-
+  const renderResponse = await app.fetch(
+    new Request('http://localhost/render?type=unstyled'),
+  )
+  const htmlText = await renderResponse.text()
   const document = new DOMParser().parseFromString(
-    tx,
+    htmlText,
     'text/html',
   )
+
   assert(document)
-  assertEquals(
-    [...document.getElementsByTagName('style')].length,
-    0,
-  )
+  await test.step('No empty style tag is injected if no Twind styles are utilised.', () => {
+    assertEquals(
+      [...document.getElementsByTagName('style')].length,
+      0,
+    )
+    assertEquals(
+      document.getElementById('unstyled')?.innerText,
+      'unstyled h3 component',
+    )
+    assertEquals(
+      renderResponse.headers.get('content-type'),
+      'text/html; charset=utf-8',
+    )
+  })
+
+  await test.step('Head meta tags are able to be injected into the HTML output properly.', () => {
+    const headElementsInDocument = [...document.getElementsByTagName('head')]
+    assert(headElementsInDocument.length === 1)
+    const headElementInDocument = headElementsInDocument.at(0)
+    assert(headElementInDocument)
+    assert(
+      [...headElementInDocument.children].find((childNode) =>
+        childNode.tagName === 'TITLE' &&
+        childNode.textContent === 'This is a document!'
+      ),
+    )
+  })
 })

--- a/test/render.test.tsx
+++ b/test/render.test.tsx
@@ -38,3 +38,33 @@ Deno.test('render', async () => {
     'text/html; charset=utf-8',
   )
 })
+
+Deno.test('No empty style tag is injected if no twind styles are utilised.', async () => {
+  const app = new cheetah()
+
+  const { render } = new Renderer()
+
+  function NonStyled() {
+    return (
+      <h3 id='styled'>
+        non-styled <code>h3</code> component
+      </h3>
+    )
+  }
+
+  app.get('/a', (c) => render(c, <NonStyled />))
+
+  const a = await app.fetch(new Request('http://localhost/a'))
+
+  const tx = await a.text()
+
+  const document = new DOMParser().parseFromString(
+    tx,
+    'text/html',
+  )
+  assert(document)
+  assertEquals(
+    [...document.getElementsByTagName('style')].length,
+    0,
+  )
+})

--- a/test/render.test.tsx
+++ b/test/render.test.tsx
@@ -37,23 +37,23 @@ const Unstyled = () => {
   )
 }
 
+const app = new cheetah()
+
+const { render } = new Renderer()
+
+app.get('/render', {
+  query: z.object({
+    type: z.union([z.literal('styled'), z.literal('unstyled')]),
+  }),
+}, (ctx) => {
+  render(
+    ctx,
+    ctx.req.query.type === 'styled' ? <Styled /> : <Unstyled />,
+  )
+})
+
 Deno.test('render', async (test) => {
-  const app = new cheetah()
-
-  const { render } = new Renderer()
-
-  app.get('/render', {
-    query: z.object({
-      type: z.union([z.literal('styled'), z.literal('unstyled')]),
-    }),
-  }, (ctx) => {
-    render(
-      ctx,
-      ctx.req.query.type === 'styled' ? <Styled /> : <Unstyled />,
-    )
-  })
-
-  await test.step('Twind styles are applied to the resulting HTML correctly', async () => {
+  await test.step('Twind styles are applied to the resulting HTML correctly.', async () => {
     const renderResponse = await app.fetch(
       new Request('http://localhost/render?type=styled'),
     )


### PR DESCRIPTION
update the JSX render class to not explicitly inject HTML inside of the body tag, allowing for head meta tags and such to be injected and handled by the browser.